### PR TITLE
Add Memcached for Friendships

### DIFF
--- a/friendships/api/serializers.py
+++ b/friendships/api/serializers.py
@@ -6,8 +6,25 @@ from rest_framework import serializers
 from rest_framework.exceptions import ValidationError
 
 
-class FollowerSerializer(serializers.ModelSerializer):
+class FollowingUserIdSetMixin:
+    @property
+    def following_user_id_set(self: serializers.ModelSerializer):
+        if self.context['request'].user.is_anonymous:
+            return {}
+        # first layer of cache, in request
+        if hasattr(self, '_cached_following_user_id_set'):
+            return self._cached_following_user_id_set
+        user_id_set = FriendshipService.get_following_user_id_set(
+            self.context['request'].user.id,
+        )
+        setattr(self, '_cached_following_user_id_set', user_id_set)
+        # user_id_set is a set of the following users id of the request user
+        return user_id_set
+
+
+class FollowerSerializer(serializers.ModelSerializer, FollowingUserIdSetMixin):
     user = UserSerializerForFriendship(source='from_user')
+    created_at = serializers.DateTimeField()
     has_followed = serializers.SerializerMethodField()
 
     class Meta:
@@ -15,13 +32,11 @@ class FollowerSerializer(serializers.ModelSerializer):
         fields = ('user', 'created_at', 'has_followed')
 
     def get_has_followed(self, obj):
-        if self.context['request'].user.is_anonymous:
-            return False
-        # TODO: further optimization of SQL query
-        return FriendshipService.has_followed(self.context['request'].user, obj.from_user)
+        # if the request user followed users in the followers list
+        return obj.from_user_id in self.following_user_id_set
 
 
-class FollowingSerializer(serializers.ModelSerializer):
+class FollowingSerializer(serializers.ModelSerializer, FollowingUserIdSetMixin):
     user = UserSerializerForFriendship(source='to_user')
     has_followed = serializers.SerializerMethodField()
 
@@ -30,10 +45,8 @@ class FollowingSerializer(serializers.ModelSerializer):
         fields = ('user', 'created_at', 'has_followed')
 
     def get_has_followed(self, obj):
-        if self.context['request'].user.is_anonymous:
-            return False
-        # TODO: further optimization of SQL query
-        return FriendshipService.has_followed(self.context['request'].user, obj.to_user)
+        # if the request user followed users in the following list
+        return obj.to_user_id in self.following_user_id_set
 
 
 class FriendshipSerializerForCreate(serializers.ModelSerializer):

--- a/friendships/listeners.py
+++ b/friendships/listeners.py
@@ -1,0 +1,3 @@
+def invalidate_following_cache(sender, instance, **kwargs):
+    from friendships.services import FriendshipService
+    FriendshipService.invalidate_following_cache(instance.from_user_id)

--- a/friendships/models.py
+++ b/friendships/models.py
@@ -1,6 +1,7 @@
-from django.db import models
 from django.contrib.auth.models import User
-
+from django.db import models
+from django.db.models.signals import pre_save, pre_delete
+from friendships.listeners import invalidate_following_cache
 
 class Friendship(models.Model):
     from_user = models.ForeignKey(
@@ -29,3 +30,7 @@ class Friendship(models.Model):
 
     def __str__(self):
         return '{} followed {}'.format(self.from_user_id, self.to_user_id)
+
+# hook up with listeners to invalidate cache
+pre_delete.connect(invalidate_following_cache, sender=Friendship)
+pre_save.connect(invalidate_following_cache, sender=Friendship)

--- a/friendships/services.py
+++ b/friendships/services.py
@@ -1,4 +1,9 @@
+from django.conf import settings
+from django.core.cache import caches
 from friendships.models import Friendship
+from twitter.cache import FOLLOWINGS_PATTERN
+
+cache = caches['testing'] if settings.TESTING else caches['default']
 
 
 class FriendshipService(object):
@@ -22,3 +27,25 @@ class FriendshipService(object):
             from_user=from_user,
             to_user=to_user,
         ).exists()
+
+    @classmethod
+    def get_following_user_id_set(cls, from_user_id):
+        key = FOLLOWINGS_PATTERN.format(user_id=from_user_id)
+        user_id_set = cache.get(key)
+        # second layer of cache, in memcached
+        # data exist in cache
+        if user_id_set is not None:
+            return user_id_set
+        # data not exist in cache, fetch from database
+        friendships = Friendship.objects.filter(from_user_id=from_user_id)
+        user_id_set = set([
+            fs.to_user_id
+            for fs in friendships
+        ])
+        cache.set(key, user_id_set)
+        return user_id_set
+
+    @classmethod
+    def invalidate_following_cache(cls, from_user_id):
+        key = FOLLOWINGS_PATTERN.format(user_id=from_user_id)
+        cache.delete(key)

--- a/friendships/tests.py
+++ b/friendships/tests.py
@@ -1,0 +1,28 @@
+from friendships.models import Friendship
+from testing.testcases import TestCase
+from friendships.services import FriendshipService
+
+
+class FriendshipServiceTests(TestCase):
+
+    def setUp(self):
+        self.clear_cache()
+        self.user1 = self.create_user('user1')
+        self.user2 = self.create_user('user2')
+
+    def test_get_followings(self):
+        user3 = self.create_user('user3')
+        user4 = self.create_user('user4')
+        for to_user in [self.user2, user3, user4]:
+            Friendship.objects.create(from_user=self.user1, to_user=to_user)
+        FriendshipService.invalidate_following_cache(self.user1)
+
+        # get following user id set success
+        user_id_set = FriendshipService.get_following_user_id_set(self.user1.id)
+        self.assertEqual(user_id_set, {self.user2.id, user3.id, user4.id})
+
+        # invalidate following cache success
+        Friendship.objects.filter(from_user=self.user1, to_user=self.user2).delete()
+        FriendshipService.invalidate_following_cache(self.user1)
+        user_id_set = FriendshipService.get_following_user_id_set(self.user1.id)
+        self.assertEqual(user_id_set, {user3.id, user4.id})

--- a/requirements.txt
+++ b/requirements.txt
@@ -41,6 +41,7 @@ pyserial==3.4
 python-apt==1.6.4
 python-dateutil==2.8.1
 python-debian==0.1.32
+python-memcached==1.59
 pytz==2021.1
 pyxdg==0.25
 PyYAML==3.12

--- a/testing/testcases.py
+++ b/testing/testcases.py
@@ -1,6 +1,7 @@
 from comments.models import Comment
 from django.contrib.auth.models import User
 from django.contrib.contenttypes.models import ContentType
+from django.core.cache import caches
 from django.test import TestCase as DjangoTestCase
 from likes.models import Like
 from newsfeeds.models import NewsFeed
@@ -9,6 +10,10 @@ from tweets.models import Tweet
 
 
 class TestCase(DjangoTestCase):
+
+    def clear_cache(self):
+        caches['testing'].clear()
+
     @property
     def anonymous_client(self):
         if hasattr(self, '_anonymous_client'):

--- a/twitter/cache.py
+++ b/twitter/cache.py
@@ -1,0 +1,2 @@
+# Memcached
+FOLLOWINGS_PATTERN = 'followings:{user_id}'

--- a/twitter/settings.py
+++ b/twitter/settings.py
@@ -161,6 +161,22 @@ if TESTING:
 AWS_STORAGE_BUCKET_NAME = 'twitter-mock'
 AWS_S3_REGION_NAME = 'us-east-1'
 
+# sudo apt-get install memcached
+# use `pip install python-memcached`
+CACHES = {
+    'default': {
+        'BACKEND': 'django.core.cache.backends.memcached.MemcachedCache',
+        'LOCATION': '127.0.0.1:11211',
+        'TIMEOUT': 86400,
+    },
+    'testing': {
+        'BACKEND': 'django.core.cache.backends.memcached.MemcachedCache',
+        'LOCATION': '127.0.0.1:11211',
+        'TIMEOUT': 86400,
+        'KEY_PREFIX': 'testing',
+    },
+}
+
 try:
     from .local_settings import *
 except:


### PR DESCRIPTION
- install `Memcached` and update settings
- create `get_following_user_id_set` method to get the followings users id and return as a set, create `FollowingUserIdSetMixin` in friendships serializers to get the `user_id_set`, and update relevant serializers with method `get_has_followed`
- create `invalidate_following_cache` to delete the key-value in cache, use listeners in model of friendships to ensure the cache is invalidated once the model is changed
- create `clear_cache` method in testcases, run and pass tests 