### PR TITLE
Support user and userprofile cache

### DIFF
--- a/accounts/api/tests.py
+++ b/accounts/api/tests.py
@@ -14,6 +14,7 @@ USER_PROFILE_DETAIL = '/api/profiles/{}/'
 class AccountApiTests(TestCase):
 
     def setUp(self):
+        self.clear_cache()
         # execute every test function
         self.client = APIClient()
         self.user = self.create_user(

--- a/accounts/listeners.py
+++ b/accounts/listeners.py
@@ -1,0 +1,8 @@
+def user_changed(sender, instance, **kwargs):
+    from accounts.services import UserService
+    UserService.invalidate_user(user_id=instance.id)
+
+
+def profile_changed(sender, instance, **kwargs):
+    from accounts.services import UserService
+    UserService.invalidate_profile(user_id=instance.user_id)

--- a/accounts/models.py
+++ b/accounts/models.py
@@ -1,5 +1,7 @@
 from django.db import models
 from django.contrib.auth.models import User
+from django.db.models.signals import pre_save, pre_delete
+from accounts.listeners import user_changed, profile_changed
 
 
 class UserProfile(models.Model):
@@ -15,11 +17,20 @@ class UserProfile(models.Model):
 
 
 def get_profile(user):
+    from accounts.services import UserService
+
     if hasattr(user, '_cached_user_profile'):
         return getattr(user, '_cached_user_profile')
-    profile, _ = UserProfile.objects.get_or_create(user=user)
+    profile = UserService.get_profile_through_cache(user.id)
     setattr(user, '_cached_user_profile', profile)
     return profile
 
 
 User.profile = property(get_profile)
+
+# hook up with listeners to invalidate cache
+pre_delete.connect(user_changed, sender=User)
+pre_save.connect(user_changed, sender=User)
+
+pre_delete.connect(profile_changed, sender=UserProfile)
+pre_save.connect(profile_changed, sender=UserProfile)

--- a/accounts/services.py
+++ b/accounts/services.py
@@ -1,0 +1,47 @@
+from accounts.models import UserProfile
+from django.conf import settings
+from django.contrib.auth.models import User
+from django.core.cache import caches
+from twitter.cache import USER_PATTERN, USER_PROFILE_PATTERN
+
+cache = caches['testing'] if settings.TESTING else caches['default']
+
+
+class UserService:
+
+    @classmethod
+    def get_user_through_cache(cls, user_id):
+        key = USER_PATTERN.format(user_id=user_id)
+        # read from cache first
+        user = cache.get(key)
+        if user is not None:
+            return user
+        # cache miss, read from database
+        try:
+            user = User.objects.get(id=user_id)
+            cache.set(key, user)
+        except User.DoesNotExist:
+            user = None
+        return user
+
+    @classmethod
+    def invalidate_user(cls, user_id):
+        key = USER_PATTERN.format(user_id=user_id)
+        cache.delete(key)
+
+    @classmethod
+    def get_profile_through_cache(cls, user_id):
+        key = USER_PROFILE_PATTERN.format(user_id=user_id)
+        # read from cache first
+        profile = cache.get(key)
+        if profile is not None:
+            return profile
+        # cache miss, read from database
+        profile, _ = UserProfile.objects.get_or_create(user_id=user_id)
+        cache.set(key, profile)
+        return profile
+
+    @classmethod
+    def invalidate_profile(cls, user_id):
+        key = USER_PROFILE_PATTERN.format(user_id=user_id)
+        cache.delete(key)

--- a/comments/api/serializers.py
+++ b/comments/api/serializers.py
@@ -7,7 +7,7 @@ from tweets.models import Tweet
 
 
 class CommentSerializer(serializers.ModelSerializer):
-    user = UserSerializerForComment()
+    user = UserSerializerForComment(source='cached_user')
     likes_count = serializers.SerializerMethodField()
     has_liked = serializers.SerializerMethodField()
 

--- a/comments/api/test.py
+++ b/comments/api/test.py
@@ -14,6 +14,7 @@ NEWSFEED_LIST_API = '/api/newsfeeds/'
 class CommentApiTests(TestCase):
 
     def setUp(self):
+        self.clear_cache()
         self.user1 = self.create_user('user1')
         self.user1_client = APIClient()
         self.user1_client.force_authenticate(self.user1)

--- a/comments/models.py
+++ b/comments/models.py
@@ -1,3 +1,4 @@
+from accounts.services import UserService
 from django.contrib.auth.models import User
 from django.contrib.contenttypes.models import ContentType
 from django.db import models
@@ -29,3 +30,7 @@ class Comment(models.Model):
             content_type=ContentType.objects.get_for_model(Comment),
             object_id=self.id,
         ).order_by('-created_at')
+
+    @property
+    def cached_user(self):
+        return UserService.get_user_through_cache(self.user_id)

--- a/friendships/api/serializers.py
+++ b/friendships/api/serializers.py
@@ -23,7 +23,7 @@ class FollowingUserIdSetMixin:
 
 
 class FollowerSerializer(serializers.ModelSerializer, FollowingUserIdSetMixin):
-    user = UserSerializerForFriendship(source='from_user')
+    user = UserSerializerForFriendship(source='cached_from_user')
     created_at = serializers.DateTimeField()
     has_followed = serializers.SerializerMethodField()
 
@@ -37,7 +37,7 @@ class FollowerSerializer(serializers.ModelSerializer, FollowingUserIdSetMixin):
 
 
 class FollowingSerializer(serializers.ModelSerializer, FollowingUserIdSetMixin):
-    user = UserSerializerForFriendship(source='to_user')
+    user = UserSerializerForFriendship(source='cached_to_user')
     has_followed = serializers.SerializerMethodField()
 
     class Meta:

--- a/friendships/api/tests.py
+++ b/friendships/api/tests.py
@@ -13,6 +13,7 @@ FOLLOWINGS_URL = '/api/friendships/{}/followings/'
 class FriendshipApiTests(TestCase):
 
     def setUp(self):
+        self.clear_cache()
         # authenticated user1 and user2
         self.user1 = self.create_user('user1')
         self.user1_client = APIClient()

--- a/friendships/models.py
+++ b/friendships/models.py
@@ -1,7 +1,9 @@
+from accounts.services import UserService
 from django.contrib.auth.models import User
 from django.db import models
 from django.db.models.signals import pre_save, pre_delete
 from friendships.listeners import invalidate_following_cache
+
 
 class Friendship(models.Model):
     from_user = models.ForeignKey(
@@ -30,6 +32,15 @@ class Friendship(models.Model):
 
     def __str__(self):
         return '{} followed {}'.format(self.from_user_id, self.to_user_id)
+
+    @property
+    def cached_from_user(self):
+        return UserService.get_user_through_cache(self.from_user_id)
+
+    @property
+    def cached_to_user(self):
+        return UserService.get_user_through_cache(self.to_user_id)
+
 
 # hook up with listeners to invalidate cache
 pre_delete.connect(invalidate_following_cache, sender=Friendship)

--- a/friendships/services.py
+++ b/friendships/services.py
@@ -22,13 +22,6 @@ class FriendshipService(object):
         return [friendship.from_user for friendship in friendships]
 
     @classmethod
-    def has_followed(cls, from_user, to_user):
-        return Friendship.objects.filter(
-            from_user=from_user,
-            to_user=to_user,
-        ).exists()
-
-    @classmethod
     def get_following_user_id_set(cls, from_user_id):
         key = FOLLOWINGS_PATTERN.format(user_id=from_user_id)
         user_id_set = cache.get(key)

--- a/inbox/api/tests.py
+++ b/inbox/api/tests.py
@@ -12,6 +12,7 @@ NOTIFICATION_MARK_URL = '/api/notifications/mark-all-as-read/'
 class NotificationTests(TestCase):
 
     def setUp(self):
+        self.clear_cache()
         self.user1, self.user1_client = self.create_user_and_client('user1')
         self.user2, self.user2_client = self.create_user_and_client('user2')
         self.tweet_user1 = self.create_tweet(self.user1)
@@ -38,7 +39,9 @@ class NotificationTests(TestCase):
 
 
 class NotificationApiTests(TestCase):
+
     def setUp(self):
+        self.clear_cache()
         self.user1, self.user1_client = self.create_user_and_client('user1')
         self.user2, self.user2_client = self.create_user_and_client('user2')
         self.tweet_user1 = self.create_tweet(self.user1)

--- a/inbox/tests.py
+++ b/inbox/tests.py
@@ -6,6 +6,7 @@ from testing.testcases import TestCase
 class NotificationServiceTests(TestCase):
 
     def setUp(self):
+        self.clear_cache()
         self.user1 = self.create_user('user1')
         self.user2 = self.create_user('user2')
         self.user1_tweet = self.create_tweet(self.user1)

--- a/likes/api/serializers.py
+++ b/likes/api/serializers.py
@@ -8,7 +8,7 @@ from tweets.models import Tweet
 
 
 class LikeSerializer(serializers.ModelSerializer):
-    user = UserSerializerForLike()
+    user = UserSerializerForLike(source='cached_user')
 
     class Meta:
         model = Like

--- a/likes/api/tests.py
+++ b/likes/api/tests.py
@@ -1,5 +1,4 @@
 from rest_framework import status
-
 from testing.testcases import TestCase
 
 LIKE_BASE_URL = '/api/likes/'
@@ -13,6 +12,7 @@ NEWSFEED_LIST_API = '/api/newsfeeds/'
 class LikeApiTests(TestCase):
 
     def setUp(self):
+        self.clear_cache()
         self.user1, self.user1_client = self.create_user_and_client('user1')
         self.user2, self.user2_client = self.create_user_and_client('user2')
 

--- a/likes/models.py
+++ b/likes/models.py
@@ -1,3 +1,4 @@
+from accounts.services import UserService
 from django.contrib.auth.models import User
 from django.contrib.contenttypes.fields import GenericForeignKey
 from django.contrib.contenttypes.models import ContentType
@@ -26,3 +27,7 @@ class Like(models.Model):
             self.content_type,
             self.object_id,
         )
+
+    @property
+    def cached_user(self):
+        return UserService.get_user_through_cache(self.user_id)

--- a/tweets/api/serializers.py
+++ b/tweets/api/serializers.py
@@ -10,7 +10,7 @@ from tweets.services import TweetService
 
 
 class TweetSerializer(serializers.ModelSerializer):
-    user = UserSerializerForTweet()
+    user = UserSerializerForTweet(source='cached_user')
     likes_count = serializers.SerializerMethodField()
     comments_count = serializers.SerializerMethodField()
     has_liked = serializers.SerializerMethodField()

--- a/tweets/api/tests.py
+++ b/tweets/api/tests.py
@@ -14,6 +14,7 @@ TWEET_RETRIEVE_API = '/api/tweets/{}/'
 class TweetApiTests(TestCase):
 
     def setUp(self):
+        self.clear_cache()
         # authenticated
         self.user1 = self.create_user('testUser1', 'user1@example.com')
         self.tweets1 = [

--- a/tweets/models.py
+++ b/tweets/models.py
@@ -1,9 +1,10 @@
+from accounts.services import UserService
 from django.contrib.auth.models import User
 from django.contrib.contenttypes.models import ContentType
 from django.db import models
 from likes.models import Like
-from utils.time_helpers import utc_now
 from tweets.constants import TweetPhotoStatus, TWEET_PHOTO_STATUS_CHOICES
+from utils.time_helpers import utc_now
 
 
 class Tweet(models.Model):
@@ -33,6 +34,10 @@ class Tweet(models.Model):
             content_type=ContentType.objects.get_for_model(Tweet),
             object_id=self.id,
         ).order_by('-created_at')
+
+    @property
+    def cached_user(self):
+        return UserService.get_user_through_cache(self.user_id)
 
 
 class TweetPhoto(models.Model):

--- a/tweets/tests.py
+++ b/tweets/tests.py
@@ -1,14 +1,14 @@
-from django.contrib.auth.models import User
-from testing.testcases import TestCase
-from tweets.models import Tweet
 from datetime import timedelta
-from utils.time_helpers import utc_now
-from tweets.models import TweetPhoto
+from testing.testcases import TestCase
 from tweets.constants import TweetPhotoStatus
+from tweets.models import TweetPhoto
+from utils.time_helpers import utc_now
 
 
 class TweetTests(TestCase):
+
     def setUp(self):
+        self.clear_cache()
         self.user1 = self.create_user('user1')
         self.tweet = self.create_tweet(self.user1)
 

--- a/twitter/cache.py
+++ b/twitter/cache.py
@@ -1,2 +1,4 @@
 # Memcached
 FOLLOWINGS_PATTERN = 'followings:{user_id}'
+USER_PATTERN = 'user:{user_id}'
+USER_PROFILE_PATTERN = 'userprofile:{user_id}'


### PR DESCRIPTION
- create `UserService` and methods to get user / userprofile through cache and invalidate the cache
- update the models to hoop up with listeners to invalidate the cache
- update relevant serializers of user, use `source` and property in model to ensure that the user is accessed from the cache first
- update tests with `clear_cache` to avoid possible cache related errors
- use newsfeeds to test get and invalidate methods, run and pass tests