### PR TITLE
Add redis as cache

### DIFF
--- a/newsfeeds/api/tests.py
+++ b/newsfeeds/api/tests.py
@@ -139,7 +139,6 @@ class NewsFeedApiTests(TestCase):
         self.user1.save()
         profile.nickname = 'user_dos'
         profile.save()
-        print(profile)
 
         response = self.user2_client.get(NEWSFEEDS_URL)
         results = response.data['results']

--- a/testing/testcases.py
+++ b/testing/testcases.py
@@ -7,12 +7,14 @@ from likes.models import Like
 from newsfeeds.models import NewsFeed
 from rest_framework.test import APIClient
 from tweets.models import Tweet
+from utils.redis_client import RedisClient
 
 
 class TestCase(DjangoTestCase):
 
     def clear_cache(self):
         caches['testing'].clear()
+        RedisClient.clear()
 
     @property
     def anonymous_client(self):

--- a/tweets/tests.py
+++ b/tweets/tests.py
@@ -2,7 +2,9 @@ from datetime import timedelta
 from testing.testcases import TestCase
 from tweets.constants import TweetPhotoStatus
 from tweets.models import TweetPhoto
+from utils.redis_client import RedisClient
 from utils.time_helpers import utc_now
+from utils.redis_serializers import DjangoModelSerializer
 
 
 class TweetTests(TestCase):
@@ -36,3 +38,15 @@ class TweetTests(TestCase):
         self.assertEqual(photo.user, self.user1)
         self.assertEqual(photo.status, TweetPhotoStatus.PENDING)
         self.assertEqual(self.tweet.tweetphoto_set.count(), 1)
+
+    def test_cache_tweet_in_redis(self):
+        tweet = self.create_tweet(self.user1)
+        conn = RedisClient.get_connection()
+        serialized_data = DjangoModelSerializer.serialize(tweet)
+        conn.set(f'tweet:{tweet.id}', serialized_data)
+        data = conn.get(f'tweet:not_exists')
+        self.assertEqual(data, None)
+
+        data = conn.get(f'tweet:{tweet.id}')
+        cached_tweet = DjangoModelSerializer.deserialize(data)
+        self.assertEqual(tweet, cached_tweet)

--- a/twitter/settings.py
+++ b/twitter/settings.py
@@ -177,6 +177,12 @@ CACHES = {
     },
 }
 
+# Redis settings
+REDIS_HOST = '127.0.0.1'
+REDIS_PORT = 6379
+REDIS_DB = 0 if TESTING else 1
+REDIS_KEY_EXPIRE_TIME = 7 * 86400  # in seconds
+
 try:
     from .local_settings import *
 except:

--- a/utils/json_encoder.py
+++ b/utils/json_encoder.py
@@ -1,0 +1,41 @@
+from django.core.serializers.json import DjangoJSONEncoder
+from django.utils.duration import duration_iso_string
+from django.utils.functional import Promise
+from django.utils.timezone import is_aware
+
+import datetime
+import decimal
+import uuid
+
+
+class JSONEncoder(DjangoJSONEncoder):
+    """
+    JSONEncoder subclass that knows how to encode date/time, decimal types, and
+    UUIDs.
+    """
+
+    def default(self, o):
+        # See "Date Time String Format" in the ECMA-262 specification.
+        if isinstance(o, datetime.datetime):
+            r = o.isoformat()
+            # MODI: make sure the datetime data precision
+            # if o.microsecond:
+            #     r = r[:23] + r[26:]
+            if r.endswith('+00:00'):
+                r = r[:-6] + 'Z'
+            return r
+        elif isinstance(o, datetime.date):
+            return o.isoformat()
+        elif isinstance(o, datetime.time):
+            if is_aware(o):
+                raise ValueError("JSON can't represent timezone-aware times.")
+            r = o.isoformat()
+            if o.microsecond:
+                r = r[:12]
+            return r
+        elif isinstance(o, datetime.timedelta):
+            return duration_iso_string(o)
+        elif isinstance(o, (decimal.Decimal, uuid.UUID, Promise)):
+            return str(o)
+        else:
+            return super().default(o)

--- a/utils/redis_client.py
+++ b/utils/redis_client.py
@@ -1,0 +1,26 @@
+from django.conf import settings
+import redis
+
+
+class RedisClient:
+    conn = None
+
+    # Singleton Pattern
+    @classmethod
+    def get_connection(cls):
+        if cls.conn:
+            return cls.conn
+        cls.conn = redis.Redis(
+            host=settings.REDIS_HOST,
+            port=settings.REDIS_PORT,
+            db=settings.REDIS_DB,
+        )
+        return cls.conn
+
+    @classmethod
+    def clear(cls):
+        # clear all keys in Redis, for testing
+        if not settings.TESTING:
+            raise Exception("You can not flush redis in production environment!")
+        conn = cls.get_connection()
+        conn.flushdb()

--- a/utils/redis_serializers.py
+++ b/utils/redis_serializers.py
@@ -1,0 +1,15 @@
+from django.core import serializers
+from utils.json_encoder import JSONEncoder
+
+
+class DjangoModelSerializer:
+
+    @classmethod
+    def serialize(cls, instance):
+        # input as QuerySet or list, make instance to list
+        return serializers.serialize('json', [instance], cls=JSONEncoder)
+
+    @classmethod
+    def deserialize(cls, serialized_data):
+        # will return object
+        return list(serializers.deserialize('json', serialized_data))[0].object

--- a/utils/tests.py
+++ b/utils/tests.py
@@ -1,0 +1,19 @@
+from testing.testcases import TestCase
+from utils.redis_client import RedisClient
+
+
+class UtilsTests(TestCase):
+
+    def SetUp(self):
+        self.clear_cache()
+
+    def test_redis_client(self):
+        conn = RedisClient.get_connection()
+        conn.lpush('redis_key', 1)
+        conn.lpush('redis_key', 2)
+        cached_list = conn.lrange('redis_key', 0, -1)
+        self.assertEqual(cached_list, [b'2', b'1'])
+
+        RedisClient.clear()
+        cached_list = conn.lrange('redis_key', 0, -1)
+        self.assertEqual(cached_list, [])


### PR DESCRIPTION
- install redis and update settings 
- create `RedisClient`, include connect and clear cache methods
- create `DjangoModelSerializer` to serialize and deserialize cache data, using modified `JSONEncoder`  to ensure the DATETIME data precision during pagination
- create utils and tweet tests, run and pass tests 