### PR TITLE
38 cache likes count and comments count

### DIFF
--- a/comments/listeners.py
+++ b/comments/listeners.py
@@ -1,4 +1,5 @@
 from utils.listeners import invalidate_object_cache
+from utils.redis_helper import RedisHelper
 
 
 def incr_comments_count(sender, instance, created, **kwargs):
@@ -10,7 +11,7 @@ def incr_comments_count(sender, instance, created, **kwargs):
 
     Tweet.objects.filter(id=instance.tweet_id) \
         .update(comments_count=F('comments_count') + 1)
-    # invalidate_object_cache(sender=Tweet, instance=instance.tweet)
+    RedisHelper.incr_count(instance.tweet, 'comments_count')
 
 
 def decr_comments_count(sender, instance, **kwargs):
@@ -19,4 +20,4 @@ def decr_comments_count(sender, instance, **kwargs):
 
     Tweet.objects.filter(id=instance.tweet_id) \
         .update(comments_count=F('comments_count') - 1)
-    # invalidate_object_cache(sender=Tweet, instance=instance.tweet)
+    RedisHelper.decr_count(instance.tweet, 'comments_count')

--- a/likes/api/tests.py
+++ b/likes/api/tests.py
@@ -255,7 +255,6 @@ class LikeApiTests(TestCase):
 
         # newsfeed api
         response = self.user1_client.get(NEWSFEED_LIST_API)
-        print(response.data)
         self.assertEqual(response.data['results'][0]['tweet']['likes_count'], 4)
         response = self.user2_client.get(NEWSFEED_LIST_API)
         self.assertEqual(response.data['results'][0]['tweet']['likes_count'], 4)
@@ -264,7 +263,9 @@ class LikeApiTests(TestCase):
         self.user2_client.post(LIKE_CANCEL_URL, data)
         tweet.refresh_from_db()
         self.assertEqual(tweet.likes_count, 3)
+        response = self.user2_client.get(tweet_url)
         self.assertEqual(response.data['likes_count'], 3)
+        response = self.user1_client.get(NEWSFEED_LIST_API)
         self.assertEqual(response.data['results'][0]['tweet']['likes_count'], 3)
         response = self.user2_client.get(NEWSFEED_LIST_API)
         self.assertEqual(response.data['results'][0]['tweet']['likes_count'], 3)

--- a/likes/listeners.py
+++ b/likes/listeners.py
@@ -1,3 +1,6 @@
+from utils.redis_helper import RedisHelper
+
+
 def incr_likes_count(sender, instance, created, **kwargs):
     from tweets.models import Tweet
     from django.db.models import F
@@ -19,8 +22,8 @@ def incr_likes_count(sender, instance, created, **kwargs):
     """
     Tweet.objects.filter(id=instance.object_id) \
         .update(likes_count=F('likes_count') + 1)
-    # SQL Query: UPDATE likes_count = likes_count + 1
-    #            FROM tweets_table WHERE id=<instance.object_id>
+    # SQL Query: UPDATE likes_count = likes_count + 1 FROM tweets_table WHERE id=<instance.object_id>
+    RedisHelper.incr_count(instance.content_object, 'likes_count')
 
 
 def decr_likes_count(sender, instance, **kwargs):
@@ -34,3 +37,4 @@ def decr_likes_count(sender, instance, **kwargs):
 
     Tweet.objects.filter(id=instance.object_id) \
         .update(likes_count=F('likes_count') - 1)
+    RedisHelper.decr_count(instance.content_object, 'likes_count')

--- a/tweets/api/serializers.py
+++ b/tweets/api/serializers.py
@@ -7,6 +7,7 @@ from rest_framework.exceptions import ValidationError
 from tweets.constants import TWEET_PHOTOS_UPLOAD_LIMIT
 from tweets.models import Tweet
 from tweets.services import TweetService
+from utils.redis_helper import RedisHelper
 
 
 class TweetSerializer(serializers.ModelSerializer):
@@ -30,12 +31,10 @@ class TweetSerializer(serializers.ModelSerializer):
         )
 
     def get_likes_count(self, obj):
-        return obj.like_set.count()
-        # return obj.likes_count
+        return RedisHelper.get_count(obj, 'likes_count')
 
     def get_comments_count(self, obj):
-        return obj.comment_set.count()
-        # return obj.comments_count
+        return RedisHelper.get_count(obj, 'comments_count')
 
     def get_has_liked(self, obj):
         return LikeService.has_liked(self.context['request'].user, obj)

--- a/utils/redis_helper.py
+++ b/utils/redis_helper.py
@@ -48,3 +48,44 @@ class RedisHelper:
         # left push
         conn.lpush(key, serialized_data)
         conn.ltrim(key, 0, settings.REDIS_LIST_LENGTH_LIMIT - 1)
+
+    @classmethod
+    def get_count_key(cls, obj, attr):
+        return '{},{}:{}'.format(obj.__class__.__name__, attr, obj.id)
+
+    @classmethod
+    def incr_count(cls, obj, attr):
+        conn = RedisClient.get_connection()
+        key = cls.get_count_key(obj, attr)
+        if not conn.exists(key):
+            # back-fill cache from db
+            obj.refresh_from_db()
+            conn.set(key, getattr(obj, attr))
+            conn.expire(key, settings.REDIS_KEY_EXPIRE_TIME)
+            return getattr(obj, attr)
+        return conn.incr(key)
+
+    @classmethod
+    def decr_count(cls, obj, attr):
+        conn = RedisClient.get_connection()
+        key = cls.get_count_key(obj, attr)
+        if not conn.exists(key):
+            # back-fill cache
+            obj.refresh_from_db()
+            conn.set(key, getattr(obj, attr))
+            conn.expire(key, settings.REDIS_KEY_EXPIRE_TIME)
+            return getattr(obj, attr)
+        return conn.decr(key)
+
+    @classmethod
+    def get_count(cls, obj, attr):
+        conn = RedisClient.get_connection()
+        key = cls.get_count_key(obj, attr)
+        count = conn.get(key)
+        if count is not None:
+            return int(count)
+
+        obj.refresh_from_db()
+        count = getattr(obj, attr)
+        conn.set(key, count)
+        return count


### PR DESCRIPTION
- create hepler methods `decr_count`, `incr_count`, `get_count` in `redis_helper`
- adjust `listeners` of `likes` and `comments` to use Redis for count increment and decrement
- adjust `serializers` of `tweets` to use Redis for count likes and comments
- run and pass test cases for cache functionality 